### PR TITLE
Replace deprecated Pylint usages

### DIFF
--- a/pylint_behave/checkers/behave_installed.py
+++ b/pylint_behave/checkers/behave_installed.py
@@ -1,6 +1,5 @@
 from pylint.checkers import BaseChecker
-from pylint.checkers.utils import check_messages
-
+from pylint.checkers.utils import only_required_for_messages
 from pylint_behave.__pkginfo__ import BASE_ERROR_ID
 
 
@@ -15,7 +14,7 @@ class BehaveInstalledChecker(BaseChecker):
         ),
     }
 
-    @check_messages('behave-not-available')
+    @only_required_for_messages('behave-not-available')
     def open(self) -> None:
         try:
             __import__('behave')

--- a/pylint_behave/plugin.py
+++ b/pylint_behave/plugin.py
@@ -13,7 +13,7 @@ def load_configuration(linter: PyLinter) -> None:
     Amend existing checker config.
     """
     name_checker = get_checker(linter, NameChecker)
-    name_checker.config.good_names += ('i', 'j', 'x', 'y')
+    name_checker.linter.config.good_names += ("i", "j", "x", "y")
 
 
 def register(linter: PyLinter) -> None:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'behave>=1.2.5',
-        'pylint>=2.0',
+        'pylint>=3.0',
         'pylint-plugin-utils>=0.5',
     ],
     python_requires='>=3.7.15',

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,10 @@ envlist =
     behave_is_installed
     pycodestyle
     pylint
-    py{37,38,39,310,311,312}-behave{125,126,-main}
-    py{37,38,39,310,311,312}-behave{125,126,-main}-nonplugin
+    py{37,38,39,310,311,312}-behave{125,126}-plugin
+    py{39,310,311,312}-behave-main-plugin
+    py{37,38,39,310,311,312}-behave{125,126}-nonplugin
+    py{39,310,311,312}-behave-main-nonplugin
 
 requires =
     pip >=20.0.2
@@ -54,7 +56,7 @@ deps =
 commands =
     pylint pylint_behave/
 
-[testenv:py{36,37,38,39,310,311,312}-behave{125,126,-main}]
+[testenv:plugin]
 commands =
     coverage run -m pytest -v pylint_behave/tests/test.py -k TestPluginCases
 
@@ -69,7 +71,7 @@ deps =
     behave-main: git+https://github.com/pycqa/astroid@main
     behave-main: git+https://github.com/pycqa/pylint@main
 
-[testenv:py{36,37,38,39,310,311,312}-behave{125,126,-main}-nonplugin]
+[testenv:nonplugin]
 commands =
     pip3 uninstall -y pylint-behave
     coverage run -m pytest -v pylint_behave/tests/test.py -k TestNonPluginCases


### PR DESCRIPTION
The `pylint-behave` plugin makes use of the `utils.check_mesages` decorator that has been dropped in Pytest >= 3.
Replace it's usage and uses of other deprecated attributes.

Since Python <= 3.8 is no longer supported by behave main branch, drop these versions from the main tox targets.